### PR TITLE
Upgrade dotenv-rails

### DIFF
--- a/dotenv-rails-safe.gemspec
+++ b/dotenv-rails-safe.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "dotenv-rails", '~> 2.1.1'
+  spec.add_dependency "dotenv-rails", '~> 2.2.1'
 
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
currently, `dotenv-rails-safe` isn't compatible with rails `5.1.1`, this update makes it work properly